### PR TITLE
Enable Target audience

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,10 @@ include = [
 [workspace]
 members = ["examples"]
 
+[dependencies.gcemeta]
+git = "https://github.com/blu-root/gcemeta"
+branch = "target-audience"
+
 [dependencies]
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 thiserror = "1.0"
@@ -30,7 +34,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_urlencoded = "0.7"
 jsonwebtoken = "8.1"
-gcemeta = "0.2"
+# gcemeta = "0.2"
 tower-service = "0.3"
 hyper = { version = "0.14", features = ["client", "http2"] }
 hyper-rustls = { version = "0.23", default-features = false, features = ["http2"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,6 @@ include = [
 [workspace]
 members = ["examples"]
 
-[dependencies.gcemeta]
-git = "https://github.com/blu-root/gcemeta"
-branch = "target-audience"
-
 [dependencies]
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 thiserror = "1.0"
@@ -34,7 +30,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_urlencoded = "0.7"
 jsonwebtoken = "8.1"
-# gcemeta = "0.2"
+gcemeta = "0.2"
 tower-service = "0.3"
 hyper = { version = "0.14", features = ["client", "http2"] }
 hyper-rustls = { version = "0.23", default-features = false, features = ["http2"], optional = true }

--- a/examples/src/tonic.rs
+++ b/examples/src/tonic.rs
@@ -8,8 +8,12 @@ use tonic::{transport::Channel, Request};
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
-    let project = env::args().nth(1).expect("cargo run --bin tonic -- <GCP_PROJECT_ID>");
-    let channel = Channel::from_static("https://pubsub.googleapis.com").connect().await?;
+    let project = env::args()
+        .nth(1)
+        .expect("cargo run --bin tonic -- <GCP_PROJECT_ID>");
+    let channel = Channel::from_static("https://pubsub.googleapis.com")
+        .connect()
+        .await?;
     let channel = GoogleAuthz::new(channel).await;
 
     let mut client = PublisherClient::new(channel);

--- a/src/auth/oauth2/http.rs
+++ b/src/auth/oauth2/http.rs
@@ -19,8 +19,12 @@ pub(super) struct Client {
 impl Client {
     pub fn new() -> Client {
         let https = connection_builder().https_only().enable_http2().build();
-        let user_agent =
-            concat!("github.com/mechiru/", env!("CARGO_PKG_NAME"), " v", env!("CARGO_PKG_VERSION"));
+        let user_agent = concat!(
+            "github.com/mechiru/",
+            env!("CARGO_PKG_NAME"),
+            " v",
+            env!("CARGO_PKG_VERSION")
+        );
         Self {
             inner: hyper::Client::builder().build(https),
             user_agent: HeaderValue::from_static(user_agent),

--- a/src/auth/oauth2/metadata.rs
+++ b/src/auth/oauth2/metadata.rs
@@ -95,5 +95,10 @@ mod test {
             &path_and_query(None, vec!["scope1".to_owned(), "scope2".to_owned()], None),
             "/computeMetadata/v1/instance/service-accounts/default/token?scopes=scope1%2Cscope2"
         );
+
+        assert_eq!(
+            &path_and_query(None, vec![], Some("https://some-service.url".to_owned())),
+            "/computeMetadata/v1/instance/service-accounts/default/token?audience=https%3A%2F%2Fsome-service.url"
+        )
     }
 }

--- a/src/auth/oauth2/metadata.rs
+++ b/src/auth/oauth2/metadata.rs
@@ -41,7 +41,11 @@ fn path_and_query(
 ) -> String {
     let mut path_and_query = "/computeMetadata/v1/instance/service-accounts/".to_owned();
     path_and_query.push_str(account.as_ref().map_or("default", String::as_str));
-    path_and_query.push_str("/token");
+    if audience.is_some() {
+        path_and_query.push_str("/identity");
+    } else {
+        path_and_query.push_str("/token");
+    }
     if let Some(aud) = audience {
         path_and_query.push('?');
         let query = AudienceQuery {
@@ -98,7 +102,7 @@ mod test {
 
         assert_eq!(
             &path_and_query(None, vec![], Some("https://some-service.url".to_owned())),
-            "/computeMetadata/v1/instance/service-accounts/default/token?audience=https%3A%2F%2Fsome-service.url"
+            "/computeMetadata/v1/instance/service-accounts/default/identity?audience=https%3A%2F%2Fsome-service.url"
         )
     }
 }

--- a/src/auth/oauth2/metadata.rs
+++ b/src/auth/oauth2/metadata.rs
@@ -22,7 +22,10 @@ impl Metadata {
     pub(crate) fn new(meta: Box<credentials::Metadata>) -> Self {
         let path_and_query = path_and_query(meta.account, meta.scopes);
         let path_and_query = PathAndQuery::from_str(&path_and_query).unwrap();
-        Self { inner: meta.client, path_and_query }
+        Self {
+            inner: meta.client,
+            path_and_query,
+        }
     }
 }
 
@@ -32,7 +35,9 @@ fn path_and_query(account: Option<String>, scopes: Vec<String>) -> String {
     path_and_query.push_str("/token");
     if !scopes.is_empty() {
         path_and_query.push('?');
-        let query = Query { scopes: &scopes.join(",") };
+        let query = Query {
+            scopes: &scopes.join(","),
+        };
         path_and_query.push_str(&serde_urlencoded::to_string(&query).unwrap());
     }
     path_and_query
@@ -47,7 +52,10 @@ impl fmt::Debug for Metadata {
 impl token::Fetcher for Metadata {
     fn fetch(&self) -> token::ResponseFuture {
         // Already checked that this process is running on GCE.
-        let fut = self.inner.get_as(self.path_and_query.clone()).map_err(auth::Error::Gcemeta);
+        let fut = self
+            .inner
+            .get_as(self.path_and_query.clone())
+            .map_err(auth::Error::Gcemeta);
         Box::pin(fut)
     }
 }

--- a/src/auth/oauth2/metadata.rs
+++ b/src/auth/oauth2/metadata.rs
@@ -26,7 +26,7 @@ impl Metadata {
     }
 }
 
-fn path_and_query(account: Option<String>, scopes: &'static [&'static str]) -> String {
+fn path_and_query(account: Option<String>, scopes: Vec<String>) -> String {
     let mut path_and_query = "/computeMetadata/v1/instance/service-accounts/".to_owned();
     path_and_query.push_str(account.as_ref().map_or("default", String::as_str));
     path_and_query.push_str("/token");
@@ -59,17 +59,17 @@ mod test {
     #[test]
     fn test_path_and_query() {
         assert_eq!(
-            &path_and_query(None, &[]),
+            &path_and_query(None, vec![]),
             "/computeMetadata/v1/instance/service-accounts/default/token"
         );
 
         assert_eq!(
-            &path_and_query(None, &["https://www.googleapis.com/auth/cloud-platform"]),
+            &path_and_query(None, vec!["https://www.googleapis.com/auth/cloud-platform".to_owned()]),
             "/computeMetadata/v1/instance/service-accounts/default/token?scopes=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcloud-platform"
         );
 
         assert_eq!(
-            &path_and_query(None, &["scope1", "scope2"]),
+            &path_and_query(None, vec!["scope1".to_owned(), "scope2".to_owned()]),
             "/computeMetadata/v1/instance/service-accounts/default/token?scopes=scope1%2Cscope2"
         );
     }

--- a/src/auth/oauth2/mod.rs
+++ b/src/auth/oauth2/mod.rs
@@ -34,7 +34,11 @@ pub(super) struct Oauth2 {
 impl Oauth2 {
     pub fn new(fetcher: Box<dyn token::Fetcher>, max_retry: u8) -> Self {
         Self {
-            inner: Arc::new(RwLock::new(Inner { state: State::NotFetched, fetcher, max_retry })),
+            inner: Arc::new(RwLock::new(Inner {
+                state: State::NotFetched,
+                fetcher,
+                max_retry,
+            })),
         }
     }
 
@@ -47,14 +51,17 @@ impl Oauth2 {
 
     #[inline]
     pub fn add_header<B>(&self, mut req: Request<B>) -> Request<B> {
-        req.headers_mut().insert(AUTHORIZATION, self.inner.read().value());
+        req.headers_mut()
+            .insert(AUTHORIZATION, self.inner.read().value());
         req
     }
 }
 
 impl fmt::Debug for Oauth2 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Oauth2").field("inner", &self.inner).finish()
+        f.debug_struct("Oauth2")
+            .field("inner", &self.inner)
+            .finish()
     }
 }
 
@@ -112,8 +119,15 @@ impl Inner {
                         attempts: 1,
                     };
                 }
-                State::Fetching { ref mut future, attempts } => poll!(Fetching, future, attempts),
-                State::Refetching { ref mut future, attempts, ref last } => {
+                State::Fetching {
+                    ref mut future,
+                    attempts,
+                } => poll!(Fetching, future, attempts),
+                State::Refetching {
+                    ref mut future,
+                    attempts,
+                    ref last,
+                } => {
                     poll!(Refetching, future, attempts, last)
                 }
                 State::Fetched { ref current } => {
@@ -153,9 +167,18 @@ impl fmt::Debug for Inner {
 
 enum State {
     NotFetched,
-    Fetching { future: RefGuard<token::ResponseFuture>, attempts: u8 },
-    Refetching { future: RefGuard<token::ResponseFuture>, attempts: u8, last: token::Token },
-    Fetched { current: token::Token },
+    Fetching {
+        future: RefGuard<token::ResponseFuture>,
+        attempts: u8,
+    },
+    Refetching {
+        future: RefGuard<token::ResponseFuture>,
+        attempts: u8,
+        last: token::Token,
+    },
+    Fetched {
+        current: token::Token,
+    },
 }
 
 impl fmt::Debug for State {

--- a/src/auth/oauth2/service_account.rs
+++ b/src/auth/oauth2/service_account.rs
@@ -31,6 +31,8 @@ struct Claims<'a> {
     aud: &'a str,
     iat: u64,
     exp: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    target_audience: Option<&'a str>,
 }
 
 #[derive(serde::Serialize)]
@@ -48,6 +50,7 @@ pub struct ServiceAccount {
     token_uri_str: String,
     scopes: String,
     client_email: String,
+    audience: Option<String>,
 }
 
 impl ServiceAccount {
@@ -60,6 +63,7 @@ impl ServiceAccount {
             token_uri_str: sa.token_uri,
             scopes: sa.scopes.join(" "),
             client_email: sa.client_email,
+            audience: sa.audience.map(Into::into),
         }
     }
 }
@@ -81,6 +85,7 @@ impl token::Fetcher for ServiceAccount {
             aud: &self.token_uri_str,
             iat,
             exp: iat + EXPIRE,
+            target_audience: self.audience.as_deref(),
         };
 
         let req = self.inner.request(&self.token_uri, &Payload {

--- a/src/auth/oauth2/service_account.rs
+++ b/src/auth/oauth2/service_account.rs
@@ -2,6 +2,7 @@ use std::{fmt, time::SystemTime};
 
 use hyper::Uri;
 use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
+use tracing::trace;
 
 use crate::{
     auth::oauth2::{http::Client, token},
@@ -95,9 +96,12 @@ impl token::Fetcher for ServiceAccount {
             }
         };
 
+        let assertion = encode(&self.header, &claims, &self.private_key).unwrap();
+        trace!(%assertion);
+
         let req = self.inner.request(&self.token_uri, &Payload {
             grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
-            assertion: &encode(&self.header, &claims, &self.private_key).unwrap(),
+            assertion: &assertion,
         });
         Box::pin(self.inner.send(req))
     }

--- a/src/auth/oauth2/service_account.rs
+++ b/src/auth/oauth2/service_account.rs
@@ -28,7 +28,8 @@ fn header(typ: impl Into<String>, key_id: impl Into<String>) -> Header {
 #[derive(serde::Serialize)]
 struct Claims<'a> {
     iss: &'a str,
-    scope: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    scope: Option<&'a str>,
     aud: &'a str,
     iat: u64,
     exp: u64,
@@ -84,7 +85,11 @@ impl token::Fetcher for ServiceAccount {
         let iat = issued_at();
         let claims = Claims {
             iss: &self.client_email,
-            scope: &self.scopes,
+            scope: if self.audience.is_some() {
+                None
+            } else {
+                Some(&self.scopes)
+            },
             aud: &self.token_uri_str,
             iat,
             exp: iat + EXPIRE,

--- a/src/auth/oauth2/service_account.rs
+++ b/src/auth/oauth2/service_account.rs
@@ -33,6 +33,8 @@ struct Claims<'a> {
     exp: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     target_audience: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    sub: Option<&'a str>,
 }
 
 #[derive(serde::Serialize)]
@@ -86,6 +88,11 @@ impl token::Fetcher for ServiceAccount {
             iat,
             exp: iat + EXPIRE,
             target_audience: self.audience.as_deref(),
+            sub: if self.audience.is_some() {
+                Some(&self.client_email)
+            } else {
+                None
+            }
         };
 
         let req = self.inner.request(&self.token_uri, &Payload {

--- a/src/auth/oauth2/service_account.rs
+++ b/src/auth/oauth2/service_account.rs
@@ -98,16 +98,19 @@ impl token::Fetcher for ServiceAccount {
                 Some(&self.client_email)
             } else {
                 None
-            }
+            },
         };
 
         let assertion = encode(&self.header, &claims, &self.private_key).unwrap();
         trace!(%assertion);
 
-        let req = self.inner.request(&self.token_uri, &Payload {
-            grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
-            assertion: &assertion,
-        });
+        let req = self.inner.request(
+            &self.token_uri,
+            &Payload {
+                grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+                assertion: &assertion,
+            },
+        );
         Box::pin(self.inner.send(req))
     }
 }

--- a/src/auth/oauth2/token.rs
+++ b/src/auth/oauth2/token.rs
@@ -69,6 +69,9 @@ impl TryFrom<Response> for Token {
                     let value = format!("Bearer {}", id_token);
                     HeaderValue::from_str(&value)
                         .map(|hv| {
+                            // TODO - to get expiry, it is reccomended to decode the recieved JWT and
+                            //  use the `exp` claim contained in the payload. See here:
+                            // https://cloud.google.com/run/docs/authenticating/service-to-service#use_the_metadata_server
                             let expiry = Instant::now() + Duration::from_secs(60 * 60);
                             Token::new(hv, expiry)
                         })

--- a/src/auth/oauth2/user.rs
+++ b/src/auth/oauth2/user.rs
@@ -41,14 +41,17 @@ impl fmt::Debug for User {
 
 impl token::Fetcher for User {
     fn fetch(&self) -> token::ResponseFuture {
-        let req = self.inner.request(&self.token_uri, &Payload {
-            client_id: &self.credentials.client_id,
-            client_secret: &self.credentials.client_secret,
-            grant_type: "refresh_token",
-            // The reflesh token is not included in the response from google's server,
-            // so it always uses the specified refresh token from the file.
-            refresh_token: &self.credentials.refresh_token,
-        });
+        let req = self.inner.request(
+            &self.token_uri,
+            &Payload {
+                client_id: &self.credentials.client_id,
+                client_secret: &self.credentials.client_secret,
+                grant_type: "refresh_token",
+                // The reflesh token is not included in the response from google's server,
+                // so it always uses the specified refresh token from the file.
+                refresh_token: &self.credentials.refresh_token,
+            },
+        );
         Box::pin(self.inner.send(req))
     }
 }

--- a/src/credentials/error.rs
+++ b/src/credentials/error.rs
@@ -14,7 +14,10 @@ pub enum Error {
     #[error(
         "user or service account credentials format error: user={user}, service_account={service_account})"
     )]
-    CredentialsFormat { user: serde_json::Error, service_account: serde_json::Error },
+    CredentialsFormat {
+        user: serde_json::Error,
+        service_account: serde_json::Error,
+    },
 }
 
 /// Wrapper for the `Result` type with an [`Error`](Error).

--- a/src/credentials/impls.rs
+++ b/src/credentials/impls.rs
@@ -1,4 +1,4 @@
-use std::{convert::TryFrom as _, env, fs, future::Future, path::Path, str::FromStr as _};
+use std::{convert::TryFrom as _, env, fs, path::Path, str::FromStr as _};
 
 use hyper::http::uri::PathAndQuery;
 use tracing::trace;
@@ -15,28 +15,34 @@ pub(super) fn from_api_key(key: String) -> Result<Credentials> {
 /// - A JSON file whose path is specified by the `GOOGLE_APPLICATION_CREDENTIALS` environment variable.
 /// - A JSON file in a location known to the gcloud command-line tool.
 /// - On Google Compute Engine, it fetches credentials from the metadata server.
-pub(super) fn find_default(
-    scopes: &'static [&'static str],
-    audience: Option<&'static str>,
-) -> impl Future<Output = Result<Credentials>> + 'static {
-    async move {
-        let credentials = if let Some(c) = from_env(scopes, audience)? {
-            c
-        } else if let Some(c) = from_well_known_file(scopes, audience)? {
-            c
-        } else if let Some(c) = from_metadata(None, scopes).await? {
-            c
-        } else {
-            return Err(Error::CredentialsSource);
-        };
-        Ok(credentials)
-    }
+pub(super) async fn find_default<'a, S, T>(
+    scopes: &'a [S],
+    audience: &'a Option<T>,
+) -> Result<Credentials>
+where
+    S: AsRef<str>,
+    String: From<&'a T>,
+{
+    let credentials = if let Some(c) = from_env(scopes, audience)? {
+        c
+    } else if let Some(c) = from_well_known_file(scopes, audience)? {
+        c
+    } else if let Some(c) = from_metadata(None, scopes).await? {
+        c
+    } else {
+        return Err(Error::CredentialsSource);
+    };
+    Ok(credentials)
 }
 
-pub(super) fn from_env(
-    scopes: &'static [&'static str],
-    audience: Option<&'static str>,
-) -> Result<Option<Credentials>> {
+pub(super) fn from_env<'a, S, T>(
+    scopes: &'a [S],
+    audience: &'a Option<T>,
+) -> Result<Option<Credentials>>
+where
+    S: AsRef<str>,
+    String: From<&'a T>,
+{
     const NAME: &str = "GOOGLE_APPLICATION_CREDENTIALS";
     trace!("try getting `{}` from environment variable", NAME);
     match env::var(NAME) {
@@ -48,10 +54,14 @@ pub(super) fn from_env(
     }
 }
 
-pub(super) fn from_well_known_file(
-    scopes: &'static [&'static str], 
-    audience: Option<&'static str>,
-) -> Result<Option<Credentials>> {
+pub(super) fn from_well_known_file<'a, S, T>(
+    scopes: &'a [S], 
+    audience: &'a Option<T>,
+) -> Result<Option<Credentials>>
+where
+    S: AsRef<str>,
+    String: From<&'a T>,
+{
     let path = {
         let mut buf = {
             #[cfg(target_os = "windows")]
@@ -80,26 +90,34 @@ pub(super) fn from_well_known_file(
     }
 }
 
-pub(super) fn from_json_file(
+pub(super) fn from_json_file<'a, S, T>(
     path: impl AsRef<Path>,
-    scopes: &'static [&'static str],
-    audience: Option<&'static str>,
-) -> Result<Credentials> {
+    scopes: &'a [S],
+    audience: &'a Option<T>,
+) -> Result<Credentials>
+where
+    S: AsRef<str>,
+    String: From<&'a T>,
+{
     trace!("try reading credentials file from {:?}", path.as_ref());
     let json = fs::read_to_string(path).map_err(Error::CredentialsFile)?;
     from_json(json.as_bytes(), scopes, audience)
 }
 
-pub(super) fn from_json(
+pub(super) fn from_json<'a, S, T>(
     json: &[u8],
-    scopes: &'static [&'static str],
-    audience: Option<&'static str>,
-) -> Result<Credentials> {
+    scopes: &'a [S],
+    audience: &'a Option<T>,
+) -> Result<Credentials>
+where
+    S: AsRef<str>,
+    String: From<&'a T>,
+{
     trace!("try deserializing to service account credentials");
     let service_account = match serde_json::from_slice::<ServiceAccount>(json) {
         Ok(mut sa) => {
-            sa.scopes = scopes;
-            sa.audience = audience;
+            sa.scopes = scopes.iter().map(|s| s.as_ref().into()).collect();
+            sa.audience = audience.as_ref().map(|s| s.into());
             return Ok(Credentials::ServiceAccount(sa));
         }
         Err(err) => {
@@ -111,7 +129,7 @@ pub(super) fn from_json(
     trace!("try deserializing to user credentials");
     let user = match serde_json::from_slice::<User>(json) {
         Ok(mut user) => {
-            user.scopes = scopes;
+            user.scopes = scopes.iter().map(|s| s.as_ref().into()).collect();
             return Ok(Credentials::User(user));
         }
         Err(err) => {
@@ -123,27 +141,29 @@ pub(super) fn from_json(
     Err(Error::CredentialsFormat { user, service_account })
 }
 
-pub(super) fn from_metadata(
+pub(super) async fn from_metadata<S: AsRef<str>>(
     account: Option<String>,
-    scopes: &'static [&'static str],
-) -> impl Future<Output = Result<Option<Credentials>>> + 'static {
+    scopes: &[S],
+) -> Result<Option<Credentials>> {
     let client = gcemeta::Client::new();
-    async move {
-        // Check if the account is valid as path string.
-        if let Some(ref account) = account {
-            let part = PathAndQuery::from_str(account).map_err(gcemeta::Error::Uri)?;
-            assert_eq!(part.path(), account);
-        }
+    // Check if the account is valid as path string.
+    if let Some(ref account) = account {
+        let part = PathAndQuery::from_str(account).map_err(gcemeta::Error::Uri)?;
+        assert_eq!(part.path(), account);
+    }
 
-        trace!("try checking if this process is running on GCE");
-        let on = client.on_gce().await?;
-        trace!("this process is running on GCE: {}", on);
+    trace!("try checking if this process is running on GCE");
+    let on = client.on_gce().await?;
+    trace!("this process is running on GCE: {}", on);
 
-        if on {
-            Ok(Some(Credentials::Metadata(Metadata { client, scopes, account }.into())))
-        } else {
-            Ok(None)
-        }
+    if on {
+        Ok(Some(Credentials::Metadata(Metadata {
+            client,
+            scopes: scopes.iter().map(|s| s.as_ref().into()).collect(),
+            account,
+        }.into())))
+    } else {
+        Ok(None)
     }
 }
 
@@ -173,12 +193,12 @@ mod test {
 "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
 "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/[SERVICE-ACCOUNT-EMAIL]"
 }"#,
-                &[],
-                None,
+                &[] as &[String],
+                &None as &Option<String>,
             )
             .unwrap(),
             Credentials::ServiceAccount(ServiceAccount {
-                scopes: &[],
+                scopes: vec![],
                 audience: None,
                 client_email: "[SERVICE-ACCOUNT-EMAIL]".into(),
                 private_key_id: "[KEY-ID]".into(),
@@ -196,12 +216,12 @@ mod test {
   "refresh_token": "refresh-xxx",
   "type": "authorized_user"
 }"#,
-                &[],
-                None,
+                &[] as &[String],
+                &None as &Option<String>,
             )
             .unwrap(),
             Credentials::User(User {
-                scopes: &[],
+                scopes: vec![],
                 client_id: "xxx.apps.googleusercontent.com".into(),
                 client_secret: "secret-xxx".into(),
                 refresh_token: "refresh-xxx".into(),

--- a/src/credentials/impls.rs
+++ b/src/credentials/impls.rs
@@ -55,7 +55,7 @@ where
 }
 
 pub(super) fn from_well_known_file<'a, S, T>(
-    scopes: &'a [S], 
+    scopes: &'a [S],
     audience: &'a Option<T>,
 ) -> Result<Option<Credentials>>
 where
@@ -121,7 +121,10 @@ where
             return Ok(Credentials::ServiceAccount(sa));
         }
         Err(err) => {
-            trace!("failed deserialize to service account credentials: {:?}", err);
+            trace!(
+                "failed deserialize to service account credentials: {:?}",
+                err
+            );
             err
         }
     };
@@ -138,7 +141,10 @@ where
         }
     };
 
-    Err(Error::CredentialsFormat { user, service_account })
+    Err(Error::CredentialsFormat {
+        user,
+        service_account,
+    })
 }
 
 pub(super) async fn from_metadata<S: AsRef<str>>(
@@ -157,11 +163,14 @@ pub(super) async fn from_metadata<S: AsRef<str>>(
     trace!("this process is running on GCE: {}", on);
 
     if on {
-        Ok(Some(Credentials::Metadata(Metadata {
-            client,
-            scopes: scopes.iter().map(|s| s.as_ref().into()).collect(),
-            account,
-        }.into())))
+        Ok(Some(Credentials::Metadata(
+            Metadata {
+                client,
+                scopes: scopes.iter().map(|s| s.as_ref().into()).collect(),
+                account,
+            }
+            .into(),
+        )))
     } else {
         Ok(None)
     }
@@ -174,7 +183,10 @@ mod test {
     #[test]
     fn test_from_api_key() {
         assert!(from_api_key("こんにちは".into()).is_err());
-        assert_eq!(from_api_key("api-key".into()).unwrap(), Credentials::ApiKey("api-key".into()));
+        assert_eq!(
+            from_api_key("api-key".into()).unwrap(),
+            Credentials::ApiKey("api-key".into())
+        );
     }
 
     #[test]

--- a/src/credentials/mod.rs
+++ b/src/credentials/mod.rs
@@ -128,7 +128,9 @@ impl<'a> Builder<'a> {
 
     #[must_use]
     pub fn metadata(mut self, account: impl Into<Option<String>>) -> Self {
-        self.source = Source::Metadata { account: account.into() };
+        self.source = Source::Metadata {
+            account: account.into(),
+        };
         self
     }
 

--- a/src/credentials/mod.rs
+++ b/src/credentials/mod.rs
@@ -56,6 +56,7 @@ pub struct ServiceAccount {
 pub struct Metadata {
     pub(crate) client: gcemeta::Client<HttpConnector>,
     pub(crate) scopes: Vec<String>,
+    pub(crate) audience: Option<String>,
     pub(crate) account: Option<String>,
 }
 
@@ -152,9 +153,11 @@ impl<'a> Builder<'a> {
             Source::ApiKey { key } => impls::from_api_key(key),
             Source::Json { data } => impls::from_json(data, &self.scopes, &self.audience),
             Source::JsonFile { path } => impls::from_json_file(path, &self.scopes, &self.audience),
-            Source::Metadata { account } => Ok(impls::from_metadata(account, &self.scopes)
-                .await?
-                .expect("this process must be running on GCE")),
+            Source::Metadata { account } => {
+                Ok(impls::from_metadata(account, &self.scopes, &self.audience)
+                    .await?
+                    .expect("this process must be running on GCE"))
+            }
         }
     }
 }

--- a/src/credentials/mod.rs
+++ b/src/credentials/mod.rs
@@ -31,7 +31,7 @@ impl Credentials {
 #[derive(Debug, serde::Deserialize)]
 pub struct User {
     #[serde(skip)]
-    pub(crate) scopes: &'static [&'static str],
+    pub(crate) scopes: Vec<String>,
     // json fields
     pub(crate) client_id: String,
     pub(crate) client_secret: String,
@@ -42,9 +42,9 @@ pub struct User {
 #[derive(Debug, serde::Deserialize)]
 pub struct ServiceAccount {
     #[serde(skip)]
-    pub(crate) scopes: &'static [&'static str],
+    pub(crate) scopes: Vec<String>,
     #[serde(skip)]
-    pub(crate) audience: Option<&'static str>,
+    pub(crate) audience: Option<String>,
     // json fields
     pub(crate) client_email: String,
     pub(crate) private_key_id: String,
@@ -55,7 +55,7 @@ pub struct ServiceAccount {
 #[derive(Debug)]
 pub struct Metadata {
     pub(crate) client: gcemeta::Client<HttpConnector>,
-    pub(crate) scopes: &'static [&'static str],
+    pub(crate) scopes: Vec<String>,
     pub(crate) account: Option<String>,
 }
 
@@ -82,15 +82,15 @@ impl<'a> Default for Source<'a> {
 }
 
 pub struct Builder<'a> {
-    scopes: &'static [&'static str],
-    audience: Option<&'static str>,
+    scopes: Vec<String>,
+    audience: Option<String>,
     source: Source<'a>,
 }
 
 impl<'a> Default for Builder<'a> {
     fn default() -> Self {
         Self {
-            scopes: &["https://www.googleapis.com/auth/cloud-platform"],
+            scopes: vec!["https://www.googleapis.com/auth/cloud-platform".to_owned()],
             source: Default::default(),
             audience: Default::default(),
         }
@@ -133,24 +133,24 @@ impl<'a> Builder<'a> {
     }
 
     #[must_use]
-    pub fn scopes(mut self, scopes: &'static [&'static str]) -> Self {
-        self.scopes = scopes;
+    pub fn scopes(mut self, scopes: &[&str]) -> Self {
+        self.scopes = scopes.iter().map(|&s| s.into()).collect();
         self
     }
 
-    pub fn audience(mut self, audience: &'static str) -> Self {
-        self.audience = Some(audience);
+    pub fn audience<S: Into<String>>(mut self, audience: S) -> Self {
+        self.audience = Some(audience.into());
         self
     }
 
     pub async fn build(self) -> Result<Credentials> {
         match self.source {
             Source::None => Ok(Credentials::None),
-            Source::Default => impls::find_default(self.scopes, self.audience).await,
+            Source::Default => impls::find_default(&self.scopes, &self.audience).await,
             Source::ApiKey { key } => impls::from_api_key(key),
-            Source::Json { data } => impls::from_json(data, self.scopes, self.audience),
-            Source::JsonFile { path } => impls::from_json_file(path, self.scopes, self.audience),
-            Source::Metadata { account } => Ok(impls::from_metadata(account, self.scopes)
+            Source::Json { data } => impls::from_json(data, &self.scopes, &self.audience),
+            Source::JsonFile { path } => impls::from_json_file(path, &self.scopes, &self.audience),
+            Source::Metadata { account } => Ok(impls::from_metadata(account, &self.scopes)
                 .await?
                 .expect("this process must be running on GCE")),
         }

--- a/src/service.rs
+++ b/src/service.rs
@@ -32,7 +32,11 @@ pub struct Builder<S> {
 
 impl Builder<()> {
     pub fn new<S>(service: S) -> Builder<S> {
-        Builder { config: Default::default(), credentials: Default::default(), service }
+        Builder {
+            config: Default::default(),
+            credentials: Default::default(),
+            service,
+        }
     }
 }
 
@@ -60,12 +64,19 @@ impl<S> Builder<S> {
     where
         S: tower_service::Service<Request<B>>,
     {
-        let Builder { config, credentials, service } = self;
+        let Builder {
+            config,
+            credentials,
+            service,
+        } = self;
         let credentials = match credentials {
             Some(credentials) => credentials,
             None => Credentials::new().await,
         };
-        GoogleAuthz { auth: Auth::new(credentials, config), service }
+        GoogleAuthz {
+            auth: Auth::new(credentials, config),
+            service,
+        }
     }
 }
 
@@ -89,7 +100,10 @@ impl GoogleAuthz<()> {
 
 impl<S: Clone> Clone for GoogleAuthz<S> {
     fn clone(&self) -> Self {
-        Self { auth: self.auth.clone(), service: self.service.clone() }
+        Self {
+            auth: self.auth.clone(),
+            service: self.service.clone(),
+        }
     }
 }
 
@@ -158,8 +172,14 @@ mod test {
             }
         }
 
-        let credentials = Credentials::builder().no_credentials().build().await.unwrap();
-        let svc = GoogleAuthz::builder(Counter(0)).credentials(credentials).build();
+        let credentials = Credentials::builder()
+            .no_credentials()
+            .build()
+            .await
+            .unwrap();
+        let svc = GoogleAuthz::builder(Counter(0))
+            .credentials(credentials)
+            .build();
         assert_send(&svc);
         assert_sync(&svc);
     }


### PR DESCRIPTION
This PR gives the ability to specify an `audience` when performing Service-to-Service connections in GCP. See [this GCP article](https://cloud.google.com/run/docs/authenticating/service-to-service#use_a_downloaded_service_account_key) for an overview of the requirements for conducting authenticated communication between services like Cloud Run.

The key change is in the use of `Credentials::builder()`. The returned builder now allows you to specify an `audience`, which is the URL of the service you are making requests to.

This will alter the downstream behaviour when requesting tokens using either the GCP Metadata server, or by using a downloaded service key. When the audience is specified, instead of requesting GCP access tokens to connect with various GCP services, it will request an ID Token, as per the above linked article.

In addition to the changes required for this, `cargo fmt` was also run.